### PR TITLE
Adds support for ruby 3.x and rails 6.x as min required versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7.6'
+          - '3.0.6'
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0.6
   Exclude:
     - 'lib/light-service-ext.rb'
     - 'vendor/bundle/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in light-service-ext.gemspec
 gemspec
 
-gem "rubocop", "~> 1.44.1"
-gem "rubocop-performance", ">= 1.16.0"
+gem 'rubocop', '~> 1.56', '>= 1.56.1'
+gem 'rubocop-performance', '~> 1.19'
 gem "rubocop-rake", ">= 0.6.0"
-gem "rubocop-rspec", ">= 2.18.1"
+gem 'rubocop-rspec', '~> 2.23', '>= 2.23.2'

--- a/lib/light-service-ext/application_context.rb
+++ b/lib/light-service-ext/application_context.rb
@@ -29,11 +29,11 @@ module LightServiceExt
     end
 
     def add_params(**params)
-      add_attrs_to_ctx(:params, params)
+      add_attrs_to_ctx(:params, **params)
     end
 
     def add_errors(**errors)
-      add_attrs_to_ctx(:errors, errors)
+      add_attrs_to_ctx(:errors, **errors)
     end
 
     def add_errors!(**errors)
@@ -77,16 +77,6 @@ module LightServiceExt
       !!self[:allow_raise_on_failure]
     end
 
-    def method_missing(method_name, *arguments, &block)
-      return self[method_name] if key?(method_name)
-
-      super
-    end
-
-    def respond_to_missing?(method_name, include_private = false)
-      key?(method_name) || super
-    end
-
     private
 
     def add_value_to_ctx(key, value)
@@ -106,6 +96,16 @@ module LightServiceExt
 
       self[key] = self[key].concat(values).compact
       nil
+    end
+
+    def method_missing(method_name, *arguments, &block)
+      return self[method_name] if key?(method_name)
+
+      super
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      key?(method_name) || super
     end
   end
 end

--- a/lib/light-service-ext/version.rb
+++ b/lib/light-service-ext/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LightServiceExt
-  VERSION = "0.1.4"
+  VERSION = "0.1.6"
 end

--- a/light-service-ext.gemspec
+++ b/light-service-ext.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.name = "light-service-ext"
   gem.require_paths = ["lib"]
   gem.version = LightServiceExt::VERSION
-  gem.required_ruby_version = ">= 2.6.0"
+  gem.required_ruby_version = ">= 3"
 
   gem.metadata["homepage_uri"] = gem.homepage
   gem.metadata["source_code_uri"] = gem.homepage
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'dry-struct', '~> 1.6'
   gem.add_runtime_dependency 'dry-validation', '~> 1.10'
   gem.add_runtime_dependency 'json', '~> 2.6', '>= 2.6.3'
-  gem.add_runtime_dependency 'activesupport', '>= 5'
+  gem.add_runtime_dependency 'activesupport', '>= 6'
 
   gem.add_development_dependency("rake", "~> 13.0.6")
   gem.add_development_dependency("rspec", "~> 3.12.0")

--- a/spec/light-service-ext/application_context_spec.rb
+++ b/spec/light-service-ext/application_context_spec.rb
@@ -11,7 +11,7 @@ module LightServiceExt
       it 'adds successful action name to context' do
         ctx.add_to_successful_actions(value)
 
-        expect(ctx.successful_actions).to match_array([value])
+        expect(ctx.successful_actions).to contain_exactly(value)
       end
 
       it 'preserves other successful action name' do
@@ -19,7 +19,7 @@ module LightServiceExt
 
         ctx.add_to_successful_actions('other-value')
 
-        expect(ctx.successful_actions).to match_array([value, 'other-value'])
+        expect(ctx.successful_actions).to contain_exactly(value, 'other-value')
       end
     end
 
@@ -27,7 +27,7 @@ module LightServiceExt
       it 'adds last api response to context' do
         ctx.add_to_api_responses(value)
 
-        expect(ctx.api_responses).to match_array([value])
+        expect(ctx.api_responses).to contain_exactly(value)
       end
 
       it 'preserves other api responses' do
@@ -35,7 +35,7 @@ module LightServiceExt
 
         ctx.add_to_api_responses('other-value')
 
-        expect(ctx.api_responses).to match_array([value, 'other-value'])
+        expect(ctx.api_responses).to contain_exactly(value, 'other-value')
       end
     end
 
@@ -263,7 +263,7 @@ module LightServiceExt
           end
 
           it 'allows for overrides' do
-            expect(ctx_with_defaults[:successful_actions]).to match_array(['some-action-class-name'])
+            expect(ctx_with_defaults[:successful_actions]).to contain_exactly('some-action-class-name')
           end
         end
 
@@ -273,7 +273,7 @@ module LightServiceExt
           end
 
           it 'allows for overrides' do
-            expect(ctx_with_defaults[:api_responses]).to match_array(['some-api-response'])
+            expect(ctx_with_defaults[:api_responses]).to contain_exactly('some-api-response')
           end
         end
 

--- a/spec/light-service-ext/application_contract_spec.rb
+++ b/spec/light-service-ext/application_contract_spec.rb
@@ -12,7 +12,7 @@ module LightServiceExt
 
     describe '.keys' do
       it 'returns schema rule keys' do
-        expect(contract_class.keys).to match_array([:email])
+        expect(contract_class.keys).to contain_exactly(:email)
       end
     end
 
@@ -38,10 +38,10 @@ module LightServiceExt
             expect(result).to be_failure
 
             errors = result.errors.to_h
-            expect(errors.keys).to match_array([:email])
+            expect(errors.keys).to contain_exactly(:email)
 
             error_messages = errors[:email]
-            expect(error_messages).to match_array(["must be a valid email"])
+            expect(error_messages).to contain_exactly("must be a valid email")
           end
         end
       end

--- a/spec/light-service-ext/configuration_spec.rb
+++ b/spec/light-service-ext/configuration_spec.rb
@@ -13,7 +13,7 @@ module LightServiceExt
 
         describe '#non_fatal_error_classes' do
           it 'returns set fatal error classes' do
-            expect(config.non_fatal_error_classes).to match_array([error_class])
+            expect(config.non_fatal_error_classes).to contain_exactly(error_class)
           end
         end
       end
@@ -27,7 +27,7 @@ module LightServiceExt
 
         describe '#default_non_fatal_error_classes' do
           it 'returns set non fatal error classes' do
-            expect(config.default_non_fatal_error_classes).to match_array([default_error_class])
+            expect(config.default_non_fatal_error_classes).to contain_exactly(default_error_class)
           end
         end
       end

--- a/spec/light-service-ext/record_actions_spec.rb
+++ b/spec/light-service-ext/record_actions_spec.rb
@@ -21,8 +21,8 @@ module LightServiceExt
 
       it 'returns expected context' do
         expect(called_ctx.success?).to be_truthy
-        expect(called_ctx.successful_actions).to match_array([])
-        expect(called_ctx.api_responses).to match_array([])
+        expect(called_ctx.successful_actions).to be_empty
+        expect(called_ctx.api_responses).to be_empty
         expect(called_ctx.status).to eql(Status::INCOMPLETE)
         expect(called_ctx[:last_failed_context]).to be_nil
       end
@@ -33,8 +33,8 @@ module LightServiceExt
 
         it 'adds api_response as last api response' do
           expect(called_ctx.success?).to be_truthy
-          expect(called_ctx.successful_actions).to match_array([action_name])
-          expect(called_ctx.api_responses).to match_array([current_api_response])
+          expect(called_ctx.successful_actions).to contain_exactly(action_name)
+          expect(called_ctx.api_responses).to contain_exactly(current_api_response)
           expect(called_ctx.status).to eql(Status::INCOMPLETE)
           expect(called_ctx[:last_failed_context]).to be_nil
         end

--- a/spec/light_service_ext_spec.rb
+++ b/spec/light_service_ext_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe LightServiceExt do
 
       describe '#non_fatal_error_classes' do
         it 'returns set fatal error classes' do
-          expect(config.non_fatal_error_classes).to match_array([error_class])
+          expect(config.non_fatal_error_classes).to contain_exactly(error_class)
         end
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe LightServiceExt do
 
       describe '#default_non_fatal_error_classes' do
         it 'returns set non fatal error classes' do
-          expect(config.default_non_fatal_error_classes).to match_array([default_error_class])
+          expect(config.default_non_fatal_error_classes).to contain_exactly(default_error_class)
         end
       end
     end


### PR DESCRIPTION
- bumps version to `0.1.6`
- `application_context.rb` ~ Added changes to support ruby 3 stricter syntax rules
- `Gemfile` and `light-service-ext.gemspec` updated to latest versions