### PR TITLE
Fix Configuration fatal_error? logic

### DIFF
--- a/lib/light-service-ext/configuration.rb
+++ b/lib/light-service-ext/configuration.rb
@@ -18,7 +18,7 @@ module LightServiceExt
     end
 
     def fatal_error?(exception)
-      !non_fatal_errors.exclude?(exception.class.name)
+      non_fatal_errors.exclude?(exception.class.name)
     end
 
     def non_fatal_error?(exception)

--- a/spec/light-service-ext/configuration_spec.rb
+++ b/spec/light-service-ext/configuration_spec.rb
@@ -87,6 +87,32 @@ module LightServiceExt
           end
         end
       end
+
+      describe '#fatal_error?' do
+        context 'with error class configured as non fatal' do
+          before { config.non_fatal_error_classes = [ArgumentError] }
+
+          it 'returns false for non fatal error' do
+            expect(config.fatal_error?(ArgumentError.new('x'))).to be_falsey
+          end
+        end
+
+        it 'returns true for unconfigured error class' do
+          expect(config.fatal_error?(RuntimeError.new('y'))).to be_truthy
+        end
+      end
+
+      describe '#non_fatal_error?' do
+        before { config.non_fatal_error_classes = [ArgumentError] }
+
+        it 'returns true when error is configured as non fatal' do
+          expect(config.non_fatal_error?(ArgumentError.new('x'))).to be_truthy
+        end
+
+        it 'returns false for unconfigured error class' do
+          expect(config.non_fatal_error?(RuntimeError.new('y'))).to be_falsey
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix inverted logic in `Configuration#fatal_error?`
- cover `fatal_error?` and `non_fatal_error?` with new specs

## Testing
- `bundle exec rspec` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840010d9cd88331b547d4bc3f0895dd