### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ class TaxCalculator < LightServiceExt::ApplicationOrganizer
   end
   
   def self.steps
-    [TaxValidator, CalcuateTaxAction]
+    [TaxValidator, CalculateTaxAction]
   end
 end
 ```


### PR DESCRIPTION
## Summary
- correct `CalcuateTaxAction` typo in README example

## Testing
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840022efb448331a07942fea29b56e7