### PR TITLE
Fix fatal_error? method and add tests

### DIFF
--- a/lib/light-service-ext/configuration.rb
+++ b/lib/light-service-ext/configuration.rb
@@ -18,7 +18,7 @@ module LightServiceExt
     end
 
     def fatal_error?(exception)
-      !non_fatal_errors.exclude?(exception.class.name)
+      non_fatal_errors.exclude?(exception.class.name)
     end
 
     def non_fatal_error?(exception)

--- a/spec/light-service-ext/configuration_spec.rb
+++ b/spec/light-service-ext/configuration_spec.rb
@@ -87,6 +87,38 @@ module LightServiceExt
           end
         end
       end
+
+      describe '#fatal_error?' do
+        context 'when error is not configured as non fatal' do
+          it 'returns true' do
+            expect(config.fatal_error?(StandardError.new)).to be_truthy
+          end
+        end
+
+        context 'when error is configured as non fatal' do
+          before { config.non_fatal_error_classes = [ArgumentError] }
+
+          it 'returns false' do
+            expect(config.fatal_error?(ArgumentError.new)).to be_falsey
+          end
+        end
+      end
+
+      describe '#non_fatal_error?' do
+        context 'when error is configured as non fatal' do
+          before { config.non_fatal_error_classes = [ArgumentError] }
+
+          it 'returns true' do
+            expect(config.non_fatal_error?(ArgumentError.new)).to be_truthy
+          end
+        end
+
+        context 'when error is not configured as non fatal' do
+          it 'returns false' do
+            expect(config.non_fatal_error?(StandardError.new)).to be_falsey
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix `fatal_error?` logic to simply rely on `exclude?`
- add tests for `fatal_error?` and `non_fatal_error?`

## Testing
- `bundle exec rspec` *(fails: rbenv version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68400238297083319a6ad81a21b52b1b